### PR TITLE
Add ablity to disable calculation of client connections

### DIFF
--- a/gstatus.py
+++ b/gstatus.py
@@ -49,7 +49,6 @@ def console_mode():
         print ("   Bricks      :%3d/%3d\t\t            %2d Up(Partial)"
                % (cluster.bricks_active, cluster.brick_count,
                   cluster.volume_summary['partial']))
-
         print ("   Connections :%3d/%4d%s%2d Down" %
                (cluster.num_clients,
                 cluster.num_connections,
@@ -132,7 +131,7 @@ def main():
     cluster.initialise()
 
     # run additional commands to get current state
-    cluster.update_state(self_heal_backlog)
+    cluster.update_state(self_heal_backlog, client_status)
 
     # use the bricks to determine overall cluster disk capacity
     cluster.calc_capacity()
@@ -175,6 +174,8 @@ if __name__ == '__main__':
     parser.add_option("-w", "--without-progress", dest="progress", action="store_true", default=False,
                       help="turn off progress updates to user during data gathering")
     parser.add_option("-t", "--timeout", dest="timeout", help="gluster command timeout value (secs)")
+    parser.add_option("-c", "--without-client-status", dest="client_status", action="store_false", default=True,
+                      help="disable building connectivity graph between bricks and clients")
     (options, args) = parser.parse_args()
 
     if options.timeout:
@@ -195,6 +196,8 @@ if __name__ == '__main__':
     display_units = options.units if options.units else 'bin'
 
     volume_list = []  # empty list of vols = show them all
+
+    client_status = options.client_status
 
     # default behaviours
     if volume_request and args:

--- a/gstatus/libgluster/cluster.py
+++ b/gstatus/libgluster/cluster.py
@@ -485,7 +485,7 @@ class Cluster(object):
 
         return self.sh_enabled
 
-    def update_state(self, self_heal_backlog):
+    def update_state(self, self_heal_backlog, client_status):
         """ update the state of the cluster by processing the output of 'vol status' commands
 
             - vol status all detail --> provides the brick info (up/down, type), plus volume capacity
@@ -638,7 +638,8 @@ class Cluster(object):
         self.active_bricks()  # update active brick counter
         self.check_self_heal()
 
-        self.calc_connections()
+        if client_status:
+            self.calc_connections()
 
     def calc_capacity(self):
         """ update the cluster's overall capacity stats based on the


### PR DESCRIPTION
Calculating 'brick/client' connections takes a lot of time on huge
gluster volumes (around 600 bricks) and sometimes fails due to timeout.
It will be great to have ability to skip such calculation if it's not required