### PR TITLE
Fix exception with no heal data

### DIFF
--- a/gstatus/glusterlib/display_status.py
+++ b/gstatus/glusterlib/display_status.py
@@ -55,12 +55,13 @@ def _build_status(data):
 
                     # Self-heal information (if any)
                     heal_i = ''
-                    for heal_data in v['healinfo']:
-                        entries = 0 if heal_data['nr_entries'] == '-' else \
-                                  heal_data['nr_entries']
-                        if int(entries) > 0:
-                            heal_i += "{:>37} {:>} ({:>} File(s) to heal).\n".\
-                                      format(' ', heal_data['name'], entries)
+                    if (v.get('healinfo', 'not found') != 'not found'):
+                        for heal_data in v['healinfo']:
+                            entries = 0 if heal_data['nr_entries'] == '-' else \
+                                      heal_data['nr_entries']
+                            if int(entries) > 0:
+                                heal_i += "{:>37} {:>} ({:>} File(s) to heal).\n".\
+                                          format(' ', heal_data['name'], entries)
                     if heal_i:
                         vols += "{:>34} Self-Heal:\n".format(' ')
                         vols += heal_i


### PR DESCRIPTION
When there is no heal data 'healinfo' is an invalid dictionary entry
for volumes and will give a KeyError: 'healinfo' when trying to print
the information from them.

This change skips trying to gather heal information for such volumes.