### PR TITLE
Install helper and Github action to make release

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -1,0 +1,36 @@
+name: "On Release"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-artifacts:
+    name: Publish gstatus and install script
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Build gstatus
+      run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,') make release
+    - name: Upload install.sh file
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: extras/install.sh
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true
+    - name: Upload gstatus to the release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: build/gstatus
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ Install
 Download the latest release with the command
 
 ```
-curl -LO https://github.com/gluster/gstatus/releases/download/v1.0.6/gstatus
-chmod +x ./gstatus
-sudo mv ./gstatus /usr/local/bin/gstatus
-gstatus --version
+$ curl -fsSL https://github.com/gluster/gstatus/releases/latest/download/install.sh | sudo bash -x
+$ gstatus --version
 ```
 
 Installating from source

--- a/extras/install.sh
+++ b/extras/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl -fsSL https://github.com/gluster/gstatus/releases/latest/download/gstatus -o /tmp/gstatus
+
+install /tmp/gstatus /usr/bin/gstatus


### PR DESCRIPTION
Create a new tag in Github UI and Github CI will build the
gstatus single file deployment file and uploads to releases
page.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>