### PR TITLE
Replace the distutils package

### DIFF
--- a/gstatus/__main__.py
+++ b/gstatus/__main__.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 from optparse import OptionParser
-from distutils.version import LooseVersion as version
+from packaging.version import parse as version
 from shutil import get_terminal_size
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 from setuptools import setup
-import distutils.command.install_scripts
 import shutil
 
 from gstatus import version
@@ -9,15 +8,6 @@ from gstatus import version
 f = open('README.md')
 long_description = f.read().strip()
 f.close()
-
-# idea from http://stackoverflow.com/a/11400431/2139420
-class strip_py_ext(distutils.command.install_scripts.install_scripts):
-    def run(self):
-        distutils.command.install_scripts.install_scripts.run(self)
-        for script in self.get_outputs():
-            if script.endswith(".py"):
-                shutil.move(script, script[:-3])
-
 
 setup(
     name = "gstatus",
@@ -28,7 +18,7 @@ setup(
     author_email = "pcuzner@redhat.com",
     url = "https://github.com/gluster/gstatus",
     license = "GPLv3",
-    install_requires=['glustercli'],
+    install_requires=['glustercli', 'packaging'],
     packages = [
         "gstatus",
         "gstatus.glusterlib",
@@ -37,8 +27,5 @@ setup(
         "console_scripts": [
             "gstatus = gstatus.__main__:main",
         ]
-    },
-    cmdclass = {
-        "install_scripts" : strip_py_ext
     }
 )


### PR DESCRIPTION
`distutils` package is deprecated. Use `packaging` library instead.

Fixes: #67